### PR TITLE
Move mappings to dto subdirectory

### DIFF
--- a/payments/internal/adapter/stripe/refund.go
+++ b/payments/internal/adapter/stripe/refund.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/shortlink-org/billing/payments/internal/application/payments/ports"
 	"github.com/shortlink-org/billing/payments/internal/domain/payment/ledger"
+	"github.com/shortlink-org/billing/payments/internal/dto"
 )
 
 // RefundPayment creates a refund for a payment through Stripe.
@@ -54,25 +55,10 @@ func (p *Provider) RefundPayment(ctx context.Context, in ports.RefundPaymentIn) 
 	out := ports.RefundPaymentOut{
 		Provider: ports.ProviderStripe,
 		RefundID: r.ID,
-		Status:   mapRefundStatus(r),
-		Amount:   fromMinor(r.Currency, r.Amount),
+		Status:   dto.MapRefundStatus(r),
+		Amount:   dto.FromMinor(r.Currency, r.Amount),
 	}
 
 	return out, nil
 }
 
-// mapRefundStatus maps Stripe refund status to provider status.
-func mapRefundStatus(r *stripe.Refund) ports.ProviderStatus {
-	switch r.Status {
-	case stripe.RefundStatusSucceeded:
-		return ports.ProviderStatusSucceeded
-	case stripe.RefundStatusPending:
-		return ports.ProviderStatusPending
-	case stripe.RefundStatusFailed:
-		return ports.ProviderStatusFailed
-	case stripe.RefundStatusCanceled:
-		return ports.ProviderStatusCanceled
-	default:
-		return ports.ProviderStatusUnknown
-	}
-}

--- a/payments/internal/dto/money.go
+++ b/payments/internal/dto/money.go
@@ -1,4 +1,4 @@
-package stripeadp
+package dto
 
 import (
 	"github.com/stripe/stripe-go/v82"
@@ -6,7 +6,7 @@ import (
 	"google.golang.org/genproto/googleapis/type/money"
 )
 
-// fromMinor converts minor currency units to money.Money.
-func fromMinor(cur stripe.Currency, v int64) *money.Money {
+// FromMinor converts minor currency units to money.Money.
+func FromMinor(cur stripe.Currency, v int64) *money.Money {
 	return ledger.MinorUnitsToAmount(string(cur), v)
 }

--- a/payments/internal/dto/stripe.go
+++ b/payments/internal/dto/stripe.go
@@ -1,0 +1,42 @@
+package dto
+
+import (
+	"github.com/stripe/stripe-go/v82"
+	"github.com/shortlink-org/billing/payments/internal/application/payments/ports"
+)
+
+// MapPIStatus maps Stripe PaymentIntent status to provider status.
+func MapPIStatus(pi *stripe.PaymentIntent) ports.ProviderStatus {
+	switch pi.Status {
+	case stripe.PaymentIntentStatusRequiresAction:
+		return ports.ProviderStatusRequiresAction
+	case stripe.PaymentIntentStatusRequiresCapture:
+		return ports.ProviderStatusRequiresCapture
+	case stripe.PaymentIntentStatusSucceeded:
+		return ports.ProviderStatusSucceeded
+	case stripe.PaymentIntentStatusRequiresPaymentMethod,
+		stripe.PaymentIntentStatusRequiresConfirmation,
+		stripe.PaymentIntentStatusProcessing:
+		return ports.ProviderStatusPending
+	case stripe.PaymentIntentStatusCanceled:
+		return ports.ProviderStatusCanceled
+	default:
+		return ports.ProviderStatusUnknown
+	}
+}
+
+// MapRefundStatus maps Stripe refund status to provider status.
+func MapRefundStatus(r *stripe.Refund) ports.ProviderStatus {
+	switch r.Status {
+	case stripe.RefundStatusSucceeded:
+		return ports.ProviderStatusSucceeded
+	case stripe.RefundStatusPending:
+		return ports.ProviderStatusPending
+	case stripe.RefundStatusFailed:
+		return ports.ProviderStatusFailed
+	case stripe.RefundStatusCanceled:
+		return ports.ProviderStatusCanceled
+	default:
+		return ports.ProviderStatusUnknown
+	}
+}


### PR DESCRIPTION
Move payment and refund status mapping functions and money conversion to a new DTO package to centralize data transfer object logic.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b065918-c76f-428c-8ea1-bb3eb0b253dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b065918-c76f-428c-8ea1-bb3eb0b253dc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Centralize DTO logic by extracting Stripe status mapping and currency conversion functions into a new dto package and updating the Stripe adapter to use these reusable utilities.

Enhancements:
- Extract Stripe PaymentIntent and refund status mapping functions into payments/internal/dto package
- Relocate minor currency to money conversion function into dto package as FromMinor
- Update Stripe payment and refund adapters to use dto.MapPIStatus, dto.MapRefundStatus, and dto.FromMinor instead of inline implementations